### PR TITLE
Latex

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "react": "0.14.x"
   },
   "dependencies": {
+    "katex": "^0.5.1",
     "react-markdown": "^1.2.1"
   }
 }

--- a/src/Transform.js
+++ b/src/Transform.js
@@ -3,6 +3,7 @@ import Immutable from 'immutable';
 import TextDisplay from './components/TextDisplay';
 import HTMLDisplay from './components/HTMLDisplay';
 import MarkdownDisplay from './components/MarkdownDisplay';
+import LaTeXDisplay from './components/LaTeXDisplay';
 
 import {
   PNGDisplay,
@@ -17,6 +18,7 @@ export const transforms = new Immutable.Map({
   'image/gif': GIFDisplay,
   'text/html': HTMLDisplay,
   'text/markdown': MarkdownDisplay,
+  'text/latex': LaTeXDisplay,
 });
 
 export const displayOrder = new Immutable.List([

--- a/src/components/LaTeXDisplay.jsx
+++ b/src/components/LaTeXDisplay.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import katex from 'katex';
+
+export default class LaTeXDisplay extends React.Component {
+  static displayName = 'LaTeXDisplay'
+
+  static propTypes = {
+    data: React.PropTypes.string,
+  }
+
+  render() {
+    return (
+      <div
+        dangerouslySetInnerHTML={{ // eslint-disable-line
+          __html: katex.renderToString(this.props.data),
+        }}/>
+    );
+  }
+}

--- a/test/components/LaTeX_spec.jsx
+++ b/test/components/LaTeX_spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { expect } from 'chai';
+
+import {
+  renderIntoDocument,
+} from 'react-addons-test-utils';
+
+import LaTeXDisplay from '../../src/components/LaTeXDisplay';
+
+describe('LaTeXDisplay', () => {
+  it('processes basic LaTeX', () => {
+    const component = renderIntoDocument(
+      <LaTeXDisplay data={'x^2 + y = 3'} />
+    );
+
+    const el = ReactDOM.findDOMNode(component);
+    expect(el).to.not.be.null;
+    expect(el.innerHTML).to.include('math');
+    expect(el.innerHTML).to.include('x^2 + y = 3');
+    // Ok, it would have a bunch more, but I'm not testing KaTeX itself
+  });
+});


### PR DESCRIPTION
Support LaTeX\*

\* This relies on `katex` which means it only supports a subset of LaTeX. In the future, I'd like to rely on https://github.com/Khan/react-components/blob/master/js/tex.jsx.

Note that any page that uses this must also include the KaTeX CSS.