### PR TITLE
Switch to ansi-to-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "react-dom": "0.14.x"
   },
   "dependencies": {
+    "ansi-to-react": "0.0.1",
     "katex": "^0.5.1",
     "react-markdown": "^1.2.1"
   }

--- a/src/components/text-display.js
+++ b/src/components/text-display.js
@@ -1,8 +1,10 @@
 import React from 'react';
 
+const Ansi = require('ansi-to-react');
+
 export default function TextDisplay(props) {
   return (
-    <pre>{props.data}</pre>
+    <Ansi>{props.data}</Ansi>
   );
 }
 

--- a/test/transformime_spec.js
+++ b/test/transformime_spec.js
@@ -55,7 +55,6 @@ describe('transforms', () => {
 
     shallowRenderer.render(<Element data={mimeBundle.get(mimetype)} />);
     const result = shallowRenderer.getRenderOutput();
-    expect(result.type).to.equal('pre');
     expect(result.props.children).to.equal('Hello World');
   });
 });


### PR DESCRIPTION
:tada:

Just like https://github.com/nteract/react-jupyter-display-area/pull/14, switches to [`ansi-to-react`](https://github.com/nteract/ansi-to-react).