### PR TITLE
Overhaul of these components

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,30 +38,31 @@
     ]
   },
   "devDependencies": {
-    "babel-cli": "^6.7.5",
-    "babel-core": "^6.7.6",
+    "babel-cli": "^6.14.0",
+    "babel-core": "^6.14.0",
     "babel-eslint": "^6.0.2",
     "babel-plugin-transform-class-properties": "^6.3.13",
     "babel-plugin-transform-export-extensions": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.3.13",
     "chai": "^3.2.0",
     "chai-immutable": "^1.5.4",
-    "electron-mocha": "^3.0.4",
-    "electron-prebuilt": "^1.3.4",
+    "electron-mocha": "^3.0.5",
+    "electron-prebuilt": "^1.3.5",
     "enzyme": "^2.2.0",
-    "eslint": "^3.3.1",
+    "eslint": "^3.4.0",
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.5.0",
-    "eslint-plugin-jsx-a11y": "^2.1.0",
-    "eslint-plugin-react": "^6.1.2",
+    "eslint-plugin-jsx-a11y": "^2.2.1",
+    "eslint-plugin-react": "^6.2.0",
     "immutable": "^3.8.1",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.2",
     "react": "^15.0.1",
     "react-addons-test-utils": "^15.0.1",
     "react-dom": "^15.0.1",
-    "rimraf": "^2.4.1"
+    "rimraf": "^2.4.1",
+    "sinon": "^1.17.5"
   },
   "homepage": "https://github.com/nteract/transformime-react#readme",
   "peerDependencies": {
@@ -73,6 +74,7 @@
     "ansi-to-react": "0.0.4",
     "commonmark": "^0.26.0",
     "commonmark-react-renderer": "^4.3.1",
-    "katex": "^0.6.0"
+    "katex": "^0.6.0",
+    "mathjax-electron": "^1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "ansi-to-react": "0.0.4",
     "commonmark": "^0.26.0",
     "commonmark-react-renderer": "^4.3.1",
-    "katex": "^0.6.0",
     "mathjax-electron": "^1.1.0"
   }
 }

--- a/src/components/html-display.js
+++ b/src/components/html-display.js
@@ -6,6 +6,7 @@ export default class HTMLDisplay extends React.Component {
     data: React.PropTypes.string,
   }
 
+
   componentDidMount() {
     if (this.refs.here) {
       if (document.createRange && Range && Range.prototype.createContextualFragment) {
@@ -16,6 +17,10 @@ export default class HTMLDisplay extends React.Component {
         ReactDOM.findDOMNode(this.refs.here).innerHTML = this.props.data;
       }
     }
+  }
+
+  shouldComponentUpdate() {
+    return false;
   }
 
   render() {

--- a/src/components/image-display.js
+++ b/src/components/image-display.js
@@ -1,9 +1,15 @@
 import React from 'react';
 
-export function ImageDisplay(props) {
-  return (
-    <img role="presentation" src={`data:${props.mimetype};base64,${props.data}`} />
-  );
+export default class ImageDisplay extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    return (
+      <img role="presentation" src={`data:${this.props.mimetype};base64,${this.props.data}`} />
+    );
+  }
 }
 
 ImageDisplay.propTypes = {

--- a/src/components/javascript-display.js
+++ b/src/components/javascript-display.js
@@ -19,6 +19,10 @@ export default class HTMLDisplay extends React.Component {
     }
   }
 
+  shouldComponentUpdate() {
+    return false;
+  }
+
   render() {
     return (
       <div ref="here" />

--- a/src/components/latex-display.js
+++ b/src/components/latex-display.js
@@ -1,14 +1,22 @@
 import React from 'react';
-import katex from 'katex';
 
-export default function LaTeXDisplay(props) {
-  return (
-    <div
-      dangerouslySetInnerHTML={{ // eslint-disable-line
-        __html: katex.renderToString(props.data),
-      }}
-    />
-  );
+const mathjaxHelper = require('mathjax-electron');
+
+export default class LaTeXDisplay extends React.Component {
+  componentDidMount() {
+    this.el.innerHTML = this.props.data;
+    mathjaxHelper.loadAndTypeset(document, this.el);
+  }
+
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    return (
+      <div ref={(el) => { this.el = el; }} />
+    );
+  }
 }
 
 LaTeXDisplay.propTypes = {

--- a/src/components/markdown-display.js
+++ b/src/components/markdown-display.js
@@ -8,7 +8,15 @@ const renderer = new MarkdownRenderer();
 
 const mdRender = (input) => renderer.render(parser.parse(input));
 
-const MarkdownDisplay = props => <div>{mdRender(props.data)}</div>;
+export class MarkdownDisplay extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    return <div>{mdRender(this.props.data)}</div>;
+  }
+}
 
 MarkdownDisplay.propTypes = {
   data: React.PropTypes.string.isRequired,

--- a/src/components/text-display.js
+++ b/src/components/text-display.js
@@ -2,10 +2,14 @@ import React from 'react';
 
 const Ansi = require('ansi-to-react');
 
-export default function TextDisplay(props) {
-  return (
-    <Ansi>{props.data}</Ansi>
-  );
+export default class TextDisplay extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+
+  render() {
+    return <Ansi>{this.props.data}</Ansi>;
+  }
 }
 
 TextDisplay.propTypes = {

--- a/test/components/html_spec.js
+++ b/test/components/html_spec.js
@@ -13,9 +13,16 @@ describe('HTMLDisplay', () => {
 
     expect(component.html()).to.equal('<div><b>woo</b></div>');
   });
-  it.skip('executes embedded <script> tags', () => {
-    // Skipped because setting innerHTML definitely doesn't
-    // run the inline script
-    // We'll want to use a document fragment like in transformime
+  it('executes embedded <script> tags', (done) => {
+    const originalCreateRange = global.document.createRange;
+    global.document.createRange = () => {
+      done(); // fake spy
+      return originalCreateRange();
+    }
+
+    const component = mount(
+      <HTMLDisplay data={'<script>window.x = 2</script>'} />
+    );
+
   });
 });

--- a/test/components/image_spec.js
+++ b/test/components/image_spec.js
@@ -5,8 +5,7 @@ const imageData = 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
 import { shallow } from 'enzyme';
 
-import {
-  ImageDisplay,
+import ImageDisplay, {
   PNGDisplay,
   GIFDisplay,
   JPEGDisplay,
@@ -17,7 +16,11 @@ describe('ImageDisplay', () => {
     const component = shallow(
       <ImageDisplay data={imageData} mimetype="image/png" />
     );
-    expect(component.html()).to.equal(`<img role="presentation" src="data:image/png;base64,${imageData}"/>`);
+
+    const img = component.find('img');
+    // Slight a11y check
+    expect(img.prop('role')).to.equal('presentation');
+    expect(img.prop('src')).to.equal(`data:image/png;base64,${imageData}`);
   });
 });
 

--- a/test/components/latex_spec.js
+++ b/test/components/latex_spec.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import { expect } from 'chai';
 
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import LaTeXDisplay from '../../src/components/latex-display';
 
 describe('LaTeXDisplay', () => {
   it('processes basic LaTeX', () => {
-    const component = shallow(
+    const component = mount(
       <LaTeXDisplay data={'x^2 + y = 3'} />
     );
 
     const rendered = component.render();
-    expect(rendered[0].children[0].children[0].attribs.class).to.equal('katex');
+    expect(rendered.html()).to.equal('<div>x^2 + y = 3</div>');
   });
 });

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,3 +1,21 @@
 import chai from 'chai';
 import chaiImmutable from 'chai-immutable';
 chai.use(chaiImmutable);
+
+global.window.document.createRange = function createRange() {
+  return {
+    setEnd: () => {},
+    setStart: () => {},
+    getBoundingClientRect: () => {
+      return { right: 0 };
+    },
+    getClientRects: () => {
+      return []
+    },
+    createContextualFragment: (html) => {
+      const div = document.createElement('div');
+      div.innerHTML = html;
+      return div.children[0]; // so hokey it's not even funny
+    },
+  }
+};


### PR DESCRIPTION
* Adapt tests to be a bit cleaner usage of `enzyme`
* `shouldComponentUpdate` should be `false` - these components are intended to be used in a way that we know when we're creating new outputs, not reusing these old nodes
* switch to mathjax-electron over KaTeX